### PR TITLE
dns64: Fix broken test

### DIFF
--- a/dns64/docker-build.conf
+++ b/dns64/docker-build.conf
@@ -1,1 +1,1 @@
-TEST_CMD="/usr/sbin/named -v"
+TEST_CMD="/usr/sbin/named-checkconf -v"


### PR DESCRIPTION
Under certain x86 systems we see this test fail. Our test setup uses
docker-in-docker. It happens against different versions of docker which
work on other systems.

We just need something for sanity, so this change should be fine as
it doesn't fail.

Signed-off-by: Andy Doan <andy@foundries.io>