### PR TITLE
OT: dns64: bind /var/bind to tmpfs

### DIFF
--- a/docker-compose.ot.yml
+++ b/docker-compose.ot.yml
@@ -8,6 +8,7 @@ services:
       - /var/lock
       - /var/log
       - /var/run
+      - /var/bind
     ports:
       - "53:53/udp"
     network_mode: "host"


### PR DESCRIPTION
DNS64 is trying to write files to /var/bind, so lets use tmpfs.

Signed-off-by: Tyler Baker <tyler@foundries.io>