### PR TITLE
ot-wpantund: Disable compiler warnings ... for now

### DIFF
--- a/ot-wpantund/Dockerfile
+++ b/ot-wpantund/Dockerfile
@@ -49,7 +49,7 @@ RUN cd ~/ && \
 	cd borderrouter && \
 	git reset --hard f42c113f3bce40b7b0066af405b99fcf09f7c98c && \
 	./bootstrap && \
-	./configure && \
+	CXXFLAGS='-g -O2 -Wall -Wextra -Wshadow -std=gnu++98 -Wno-c++14-compat' ./configure && \
 	make && \
 	cp tools/pskc /usr/local/sbin/
 


### PR DESCRIPTION
I've got an upstream issue/pr trying to deal with this:

 https://github.com/openthread/borderrouter/pull/245

It may take a while to get them to full fix this issue, so lets just
disable -Werror for now.

Signed-off-by: Andy Doan <andy@foundries.io>