### PR TITLE
container changes for v41

### DIFF
--- a/nat64-jool/Dockerfile
+++ b/nat64-jool/Dockerfile
@@ -1,0 +1,39 @@
+# STAGE 1
+FROM alpine:latest as jool-dev
+
+LABEL maintainer="Michael Scott <mike@foundries.io>"
+
+ENV \
+	JOOL_VERSION=4.0.0
+
+RUN apk add --no-cache \
+	bash git libc-dev make automake autoconf gcc libnl3-dev iptables-dev \
+	argp-standalone
+
+# Make jool stateful userspace
+RUN \
+	git clone https://github.com/NICMx/Jool -b v${JOOL_VERSION} && \
+	cd Jool/ && \
+	./autogen.sh && \
+	./configure && \
+	cd src/usr/iptables && \
+	make && \
+	make install && \
+	cd ../nat64 && \
+	make && \
+	make install
+
+# STAGE 2
+FROM alpine:latest
+
+LABEL maintainer="Michael Scott <mike@foundries.io>"
+
+RUN apk add --no-cache libstdc++ libgcc libnl3 iptables
+
+COPY --from=jool-dev /usr/lib/xtables/libxt_JOOL.so /usr/lib/xtables/
+COPY --from=jool-dev /usr/local/bin/jool /usr/local/bin/
+COPY --from=jool-dev /usr/local/share/man/man8/jool.8 /usr/share/man/man8/
+
+COPY start.sh start.sh
+
+ENTRYPOINT ["/start.sh"]

--- a/nat64-jool/README.md
+++ b/nat64-jool/README.md
@@ -1,0 +1,23 @@
+Jool is an Open Source SIIT and NAT64 for Linux.
+For more information: [visit Jool website](https://www.jool.mx/en/index.html).
+
+Specifically, this container sets up Jool kernel module for NAT64.
+
+## How to use this image
+
+```
+docker run --privileged --network=host -v /lib/modules:/lib/modules:ro \
+    hub.foundries.io/nat64-jool
+```
+
+The following parameter can be passed into the container at the end of the
+above command:
+
+- --nat64-prefix: destination IPv6 prefix denoting IPv4 NAT traffic
+  (default: 64:ff9b::/96)
+
+Example:
+```
+docker run --privileged --network=host -v /lib/modules:/lib/modules:ro \
+    hub.foundries.io/nat64-jool --nat64-prefix "64:ff9b::/96"
+```

--- a/nat64-jool/docker-build.conf
+++ b/nat64-jool/docker-build.conf
@@ -1,0 +1,1 @@
+TEST_CMD="/usr/local/bin/jool --version"

--- a/nat64-jool/start.sh
+++ b/nat64-jool/start.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+#
+# Copyright (c) 2019 Foundries.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+JOOL_NAT64_PREFIX="64:ff9b::/96"
+
+function parse_args()
+{
+    while [ $# -gt 0 ]
+    do
+        case $1 in
+        --nat64-prefix)
+            JOOL_NAT64_PREFIX=$2
+            shift
+            shift
+            ;;
+        *)
+            shift
+            ;;
+        esac
+    done
+}
+
+parse_args "$@"
+
+# Unload existing module
+if [ ! -z "$(lsmod | grep jool)" ]; then
+    echo "Removing installed jool.ko"
+    rmmod jool.ko
+fi
+
+# Turn on forwarding
+sysctl -w net.ipv6.conf.all.disable_ipv6=0
+sysctl -w net.ipv6.conf.all.forwarding=1
+sysctl -w net.ipv4.ip_forward=1
+
+# Load Jool kernel module
+echo "Installing jool module"
+modprobe jool
+
+echo "Setting up default pool"
+jool instance add "default" --netfilter --pool6 ${JOOL_NAT64_PREFIX}
+
+# Wait till cancel
+while true; do sleep 60; done

--- a/radvd64/interface-monitor.sh
+++ b/radvd64/interface-monitor.sh
@@ -21,21 +21,19 @@ RADVD_MASK="$3"
 
 function iface_setup()
 {
-	echo "[IM] interface: ${RADVD_INTERFACE} add IPv6 address: ${RADVD_PREFIX}1"
-	ip addr add "${RADVD_PREFIX}1" dev "${RADVD_INTERFACE}"
-	echo "[IM] interface: ${RADVD_INTERFACE} add route: ${RADVD_PREFIX}/${RADVD_MASK}"
-	ip -6 route add "${RADVD_PREFIX}/${RADVD_MASK}" dev "${RADVD_INTERFACE}"
+	# check IP
+	ip -6 address show dev "${RADVD_INTERFACE}" | grep -q "${RADVD_PREFIX}1/${RADVD_MASK}"
+	if [ $? -ne 0 ]; then
+		echo "[IM] interface: ${RADVD_INTERFACE} add IPv6 address: ${RADVD_PREFIX}1"
+		ip addr add "${RADVD_PREFIX}1/${RADVD_MASK}" dev "${RADVD_INTERFACE}"
+	fi
 }
 
 function iface_monitor()
 {
 	# if interface already exists assign IPv6 prefix and route to interface
 	if [ -e /sys/class/net/${RADVD_INTERFACE} ]; then
-		ip -6 address show dev ${RADVD_INTERFACE} | grep -q ${RADVD_PREFIX}
-		if [ $? -ne 0 ]; then
-			echo "[IM] interface: ${RADVD_INTERFACE} is UP w/o prefix"
-			iface_setup
-		fi
+		iface_setup
 	fi
 
 	dbus-monitor --system "type='signal',path='/org/freedesktop/systemd1',member=UnitNew" |


### PR DESCRIPTION
3 main changes in this PR:
- Add the nat64-jool container as a replacement for nat64-tayga
- Fixup for the interface monitor in radvd64 container
- Update the docker-compose files to use NAT64/DNS64-based containers and drop the use of NGINX.  This makes the stack *almost* identical between BLE 6lowpan and OpenThread with the exception of the ot-wpantund container.