### PR TITLE
dns64: fix IPv6 port bindings

### DIFF
--- a/dns64/named.conf.template
+++ b/dns64/named.conf.template
@@ -8,8 +8,8 @@ options {
 
 	allow-query { any; };
 
-	# Listening on IPv6 is off by default.
-	listen-on-v6 { any; };
+	# Listening on IPv6 is off by default -- use bt0 / wpan0 IPs
+	listen-on-v6 port 53 { fd11:11::1; fd11:22::1; };
 
 	dns64 %NAT64_PREFIX% {
 		exclude { any; };

--- a/dns64/start.sh
+++ b/dns64/start.sh
@@ -78,5 +78,5 @@ do
 	fi
 done < "/etc/hosts"
 
-# Run BIND
-/usr/sbin/named -c ${BIND_CONF_USE} -f -g
+# Run BIND on port 5354 so that we don't abort due to port 53 usage errors
+/usr/sbin/named -c ${BIND_CONF_USE} -f -g -p 5354


### PR DESCRIPTION
Due to latest OE changes fixing bindings on port 53, we need to change
how the DNS64 container listends on IPv6 ports.

To do this:
- Don't bind to port 53 on IPv4 addresses. Any failure here will abort
  the container.
- Instead bind to a semi-random port: 5354 for IPv4, this should always
  succeed.
- Use dynamic port 53 bindings on our 6lowpan addresses.  This will
  trigger as soon as the interface comes up.

Signed-off-by: Michael Scott <mike@foundries.io>