### PR TITLE
dns64: remove forwarder configuration

### DIFF
--- a/dns64/named.conf.template
+++ b/dns64/named.conf.template
@@ -3,9 +3,6 @@ options {
 	dnssec-validation auto;
 	auth-nxdomain no;
 
-	forward only;
-	forwarders { %FORWARDER_LIST%; };
-
 	allow-query { any; };
 
 	# Listening on IPv6 is off by default -- use bt0 / wpan0 IPs

--- a/dns64/start.sh
+++ b/dns64/start.sh
@@ -21,7 +21,6 @@ BIND_CONF_USE="/var/bind/named.conf"
 RPZ_ZONE_TEMPLATE="/etc/bind/db.rpz.template"
 RPZ_ZONE_USE="/var/bind/db.rpz"
 
-FORWARDER_LIST="8.8.8.8; 8.8.8.4"
 NAT64_PREFIX="64:ff9b::"
 NAT64_MASK=96
 
@@ -30,11 +29,6 @@ function parse_args()
     while [ $# -gt 0 ]
     do
         case $1 in
-        --forwarder-list)
-            FORWARDER_LIST=$2
-            shift
-            shift
-            ;;
         --nat64-prefix)
             NAT64_PREFIX=$2
             shift
@@ -56,7 +50,6 @@ parse_args "$@"
 
 # Create working copy of named.conf.template
 cp ${BIND_CONF_TEMPLATE} ${BIND_CONF_USE}
-sed -i -e "s/%FORWARDER_LIST%/${FORWARDER_LIST}/g" ${BIND_CONF_USE}
 sed -i -e "s/%NAT64_PREFIX%/${NAT64_PREFIX}\/${NAT64_MASK}/g" ${BIND_CONF_USE}
 
 # Create an RPZ zone from db.rpz.template


### PR DESCRIPTION
Google DNS denies DNSSEC requests and this causes issues with queries
being returned correctly.  Also, there's no real need to rely on a
"forwarder" DNS setup.  Let's eliminate the middle-man and some of
the complexity of this container.

Signed-off-by: Michael Scott <mike@foundries.io>