### PR TITLE
iface-monitor: update to python3

### DIFF
--- a/iface-monitor/Dockerfile
+++ b/iface-monitor/Dockerfile
@@ -17,7 +17,7 @@ FROM alpine:latest
 
 LABEL maintainer="Michael Scott <mike@foundries.io>"
 
-RUN apk add --no-cache dbus py-dbus py-gobject3
+RUN apk add --no-cache dbus python3 py3-dbus py3-gobject3
 
 COPY interface-monitor.py interface-monitor.py
 COPY start.sh start.sh

--- a/iface-monitor/docker-build.conf
+++ b/iface-monitor/docker-build.conf
@@ -1,1 +1,1 @@
-TEST_CMD="python2 /interface-monitor.py --help"
+TEST_CMD="python3 /interface-monitor.py --help"

--- a/iface-monitor/interface-monitor.py
+++ b/iface-monitor/interface-monitor.py
@@ -9,10 +9,7 @@ import dbus.mainloop.glib
 import subprocess
 import os.path
 import time
-try:
-    from gi.repository import GObject
-except ImportError:
-    import gobject as GObject
+from gi.repository import GLib
 
 aborted = False
 
@@ -73,5 +70,5 @@ if __name__ == '__main__':
                             path='/org/freedesktop/systemd1',
                             member_keyword='member')
 
-    mainloop = GObject.MainLoop()
+    mainloop = GLib.MainLoop()
     mainloop.run()

--- a/iface-monitor/start.sh
+++ b/iface-monitor/start.sh
@@ -53,4 +53,4 @@ rm -rf /run/dbus/
 ln -s /var/dbus /run/dbus
 
 # Run interface monitor
-python2 /interface-monitor.py -i ${MON_INTERFACE} -d ${MON_DYN_IP} -s ${MON_SECONDS_DELAY}
+python3 /interface-monitor.py -i ${MON_INTERFACE} -d ${MON_DYN_IP} -s ${MON_SECONDS_DELAY}


### PR DESCRIPTION
- current alpine was missing python install, so added it explicitly
- update to python3 now that py-dbus supports it
- remove deprecated use of GObject.Mainloop

Signed-off-by: Michael Scott <mike@foundries.io>