### PR TITLE
docker-compose: ble: fix iface-monitor parameters

### DIFF
--- a/docker-compose.ble.yml
+++ b/docker-compose.ble.yml
@@ -7,7 +7,7 @@ services:
       - /run
       - /var/lock
       - /var/log
-    command: "--interface bt0 --ipv6-prefix \"fd11:11::\" --ipv6-mask 64"
+    command: "--interface bt0 --ip \"fd11:11::1/64\""
     network_mode: "host"
     restart: always
     read_only: true


### PR DESCRIPTION
These parameters are incorrect.  The only reason iface-monitor was
working for bt0 was that the defaults in the script were for..
bt0 with the correct gateway IP.

Signed-off-by: Michael Scott <mike@foundries.io>